### PR TITLE
Add IntentHandler and Response for GetConnectionStatus Shortcut

### DIFF
--- a/ProtonVPN/Info.plist
+++ b/ProtonVPN/Info.plist
@@ -55,6 +55,7 @@
 	<key>NSUserActivityTypes</key>
 	<array>
 		<string>DisconnectIntent</string>
+		<string>GetConnectionStatusIntent</string>
 		<string>QuickConnectIntent</string>
 	</array>
 	<key>UILaunchStoryboardName</key>

--- a/Siri Shortuct Handler/Info.plist
+++ b/Siri Shortuct Handler/Info.plist
@@ -44,6 +44,7 @@
 			<key>IntentsSupported</key>
 			<array>
 				<string>DisconnectIntent</string>
+				<string>GetConnectionStatusIntent</string>
 				<string>QuickConnectIntent</string>
 			</array>
 		</dict>

--- a/Siri Shortuct Handler/IntentHandler.swift
+++ b/Siri Shortuct Handler/IntentHandler.swift
@@ -24,7 +24,7 @@ import Intents
 import vpncore
 
 @available(iOSApplicationExtension 12.0, *)
-class IntentHandler: INExtension, QuickConnectIntentHandling, DisconnectIntentHandling {
+class IntentHandler: INExtension, QuickConnectIntentHandling, DisconnectIntentHandling, GetConnectionStatusIntentHandling {
     
     let siriHandlerViewModel: SiriHandlerViewModel
     
@@ -41,6 +41,10 @@ class IntentHandler: INExtension, QuickConnectIntentHandling, DisconnectIntentHa
     
     func handle(intent: DisconnectIntent, completion: @escaping (DisconnectIntentResponse) -> Void) {
         siriHandlerViewModel.disconnect(completion)
+    }
+    
+    func handle(intent: GetConnectionStatusIntent, completion: @escaping (GetConnectionStatusIntentResponse) -> Void) {
+        siriHandlerViewModel.getConnectionStatus(completion)
     }
     
     override func handler(for intent: INIntent) -> Any {

--- a/Siri Shortuct Handler/SiriHandlerViewModel.swift
+++ b/Siri Shortuct Handler/SiriHandlerViewModel.swift
@@ -117,19 +117,13 @@ class SiriHandlerViewModel {
     }
     
     public func getConnectionStatus(_ completion: @escaping (GetConnectionStatusIntentResponse) -> Void) {
-        guard let vpnGateway = vpnGateway else {
-            // Not logged in so open the app
-            completion(GetConnectionStatusIntentResponse(code: .failureRequiringAppLaunch, userActivity: nil))
-            return
-        }
-        
-        let status = getConnectionStatusString(connection: vpnGateway.connection)
+        let status = getConnectionStatusString(connection: vpnGateway?.connection)
         let response = GetConnectionStatusIntentResponse.success(status: status)
         
         completion(response)
     }
     
-    private func getConnectionStatusString(connection: ConnectionStatus) -> String {
+    private func getConnectionStatusString(connection: ConnectionStatus?) -> String {
         switch connection {
         case .connected:
             return LocalizedString.connected
@@ -139,6 +133,8 @@ class SiriHandlerViewModel {
             return LocalizedString.disconnected
         case .disconnecting:
             return LocalizedString.disconnecting
+        default:
+            return LocalizedString.vpnStatusNotLoggedIn
         }
     }
     

--- a/Siri Shortuct Handler/SiriHandlerViewModel.swift
+++ b/Siri Shortuct Handler/SiriHandlerViewModel.swift
@@ -116,6 +116,32 @@ class SiriHandlerViewModel {
         }
     }
     
+    public func getConnectionStatus(_ completion: @escaping (GetConnectionStatusIntentResponse) -> Void) {
+        guard let vpnGateway = vpnGateway else {
+            // Not logged in so open the app
+            completion(GetConnectionStatusIntentResponse(code: .failureRequiringAppLaunch, userActivity: nil))
+            return
+        }
+        
+        let status = getConnectionStatusString(connection: vpnGateway.connection)
+        let response = GetConnectionStatusIntentResponse.success(status: status)
+        
+        completion(response)
+    }
+    
+    private func getConnectionStatusString(connection: ConnectionStatus) -> String {
+        switch connection {
+        case .connected:
+            return LocalizedString.connected
+        case .connecting:
+            return LocalizedString.connecting
+        case .disconnected:
+            return LocalizedString.disconnected
+        case .disconnecting:
+            return LocalizedString.disconnecting
+        }
+    }
+    
     @objc private func connectionChanged() {
         guard let currentAction = currentAction else { return }
         


### PR DESCRIPTION
Associated: https://github.com/ProtonVPN/vpncore/pull/2#issue-366106854

New Shortcut:
GetConnectionStatus() -> Localized String of VpnGateway.ConnectionStatus enum

Purpose:
Allow users to determine ProtonVPN's connection state in SiriShortcuts